### PR TITLE
Add transparent gz file handling. Zip case throwing an error still

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ clap = { version = "4.5.18", features = ["derive"] }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
 regex = "1.11.0"
+flate2 = "1.0.34"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod cpedict;
 use cpedict::parse_cpe_node;
+pub mod nvdarchive;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 use roxmltree;
 use rayon::prelude::*;
 use clap::Parser;
@@ -35,6 +36,7 @@ struct Args {
 }
 
 use cpe_explorer::cpedict::{parse_cpe_node, CpeEntry, CVE_CPE23_VALID_REGEX_STR};
+use cpe_explorer::nvdarchive;
 
 fn main() {
     let cpe23_valid_regex = Regex::new(CVE_CPE23_VALID_REGEX_STR).unwrap();
@@ -42,9 +44,11 @@ fn main() {
     let args = Args::parse();
     
     //Read in XML
-    let input_xml_file = args.dict;
-    let raw_xml = fs::read_to_string(input_xml_file)
-                .expect("could not read input file");
+    let input_xml_file = Path::new(&args.dict);
+    let raw_xml = nvdarchive::decompress_or_return(input_xml_file)
+        .expect("could not read input file");
+    // let raw_xml = fs::read_to_string(input_xml_file)
+    //             .expect("could not read input file");
     let cpe_xml_doc = roxmltree::Document::parse(&raw_xml).expect("could not parse input xml");
     
     let cpe_list = cpe_xml_doc.root_element();

--- a/src/nvdarchive.rs
+++ b/src/nvdarchive.rs
@@ -1,0 +1,33 @@
+use std::fs;
+use std::path::Path;
+use std::ffi::OsStr;
+use std::io::prelude::*;
+use std::io::{Error, ErrorKind};
+use flate2::read::{GzDecoder, DeflateDecoder};
+
+// Handle all three cases of NVD dict (gz, zip, or decompressed xml)
+pub fn decompress_or_return(cpe_dict_path: &Path) -> Result<String, std::io::Error> {
+	match cpe_dict_path.extension().and_then(OsStr::to_str) {
+		Some("gz") => {
+			let data = fs::read(cpe_dict_path)?;
+			let mut gz = GzDecoder::new(data.as_slice());
+			let mut s = String::new();
+			gz.read_to_string(&mut s)?;
+			Ok(s)
+		},
+		Some("zip") => {
+			let data = fs::read(cpe_dict_path)?;
+			let mut deflater = DeflateDecoder::new(data.as_slice());
+			let mut s = String::new();
+			deflater.read_to_string(&mut s)?;
+			Ok(s)
+		},
+		Some("xml") => {
+			match fs::read_to_string(cpe_dict_path) {
+				Ok(s) => Ok(s),
+				Err(e) => Err(e),
+			}
+		},
+		_ => {Err(Error::new(ErrorKind::Other, "Invalid Dictionary File Extension"))}
+	}
+}


### PR DESCRIPTION
Need more time to look into the zip file case. Searching for the string `corrupt deflate stream` shows that others are have the same issue with flate2.